### PR TITLE
refactor: use Board.SIZE for CpuPlayer scan

### DIFF
--- a/src/controller/CpuPlayer.ts
+++ b/src/controller/CpuPlayer.ts
@@ -7,7 +7,6 @@ import { RandomEval } from "./eval/RandomEval";
 
 export class CpuPlayer implements IPlayer {
   public readonly color: StoneColor;
-  public static readonly BOARD_SIZE = 8;
   private readonly rng: () => number; // 乱数生成器
   private readonly strategy: IEvalStrategy | null; // 評価戦略
 
@@ -26,8 +25,8 @@ export class CpuPlayer implements IPlayer {
   public chooseMove(board: Board): Position | null {
     /* ---------- 合法手の列挙 ---------- */
     const validMoves: Position[] = [];
-    for (let r = 0; r < CpuPlayer.BOARD_SIZE; r++) {
-      for (let c = 0; c < CpuPlayer.BOARD_SIZE; c++) {
+    for (let r = 0; r < Board.SIZE; r++) {
+      for (let c = 0; c < Board.SIZE; c++) {
         if (board.canPutStone(r, c, this.color)) {
           validMoves.push({ row: r, col: c });
         }

--- a/src/view/BoardCanvas.ts
+++ b/src/view/BoardCanvas.ts
@@ -4,7 +4,6 @@ import { Position } from "../types/Position";
 
 export class BoardCanvas {
   public readonly element: HTMLDivElement;
-  public static readonly SIZE = 8;
   private readonly cells: HTMLDivElement[][] = [];
   private readonly onCellClick: (r: number, c: number) => void;
   private readonly highlighted = new Set<string>();// "row,col" 形式で管理
@@ -16,12 +15,12 @@ export class BoardCanvas {
     this.element = document.createElement("div");
     this.element.classList.add("board-canvas");
 
-    for (let r = 0; r < BoardCanvas.SIZE; r++) {
+    for (let r = 0; r < Board.SIZE; r++) {
       const rowEl = document.createElement("div");
       rowEl.classList.add("board-row");
       const rowArr: HTMLDivElement[] = [];
 
-      for (let c = 0; c < BoardCanvas.SIZE; c++) {
+      for (let c = 0; c < Board.SIZE; c++) {
         const cellEl = document.createElement("div");
         cellEl.classList.add("board-cell");
         cellEl.dataset.row = String(r);
@@ -47,8 +46,8 @@ export class BoardCanvas {
 
 
   public render(board: Board): void {
-    for (let r = 0; r < BoardCanvas.SIZE; r++) {
-      for (let c = 0; c < BoardCanvas.SIZE; c++) {
+    for (let r = 0; r < Board.SIZE; r++) {
+      for (let c = 0; c < Board.SIZE; c++) {
         const cell = this.cells[r][c];
         cell.classList.remove("black", "white", "empty");
 
@@ -78,7 +77,7 @@ export class BoardCanvas {
 
     /* 新ハイライト適用 */
     valid.forEach(({ row, col }) => {
-      if (row < 0 || row >= BoardCanvas.SIZE || col < 0 || col >= BoardCanvas.SIZE) return;
+      if (row < 0 || row >= Board.SIZE || col < 0 || col >= Board.SIZE) return;
       this.cells[row][col].classList.add("highlight");
       this.highlighted.add(`${row},${col}`);
     });


### PR DESCRIPTION
## Summary
- remove redundant BOARD_SIZE constant from CpuPlayer
- scan board using Board.SIZE directly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abbae558f0832e9bb14e9d86b95290